### PR TITLE
add borrow_fd method to Slave and Master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,20 @@
+name: nightly
+on:
+  schedule:
+    - cron: '04 05 * * *'
+
+jobs:
+  deny:
+    name: cargo deny --all-features check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+          bins: cargo-deny
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo deny --all-features check
+
+  postsubmit:
+    uses: ./.github/workflows/presubmit.yml

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,51 @@
+name: presubmit
+on: [pull_request, workflow_call, workflow_dispatch]
+
+jobs:
+  test:
+    name: cargo test --all-features
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo test --all-features
+      - run: cargo test --no-default-features
+
+  rustfmt:
+    name: cargo +nightly fmt -- --check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          components: rustfmt
+          channel: nightly
+      - run: cargo +nightly fmt -- --check
+
+  cranky:
+    name: cargo +nightly cranky --all-targets -- -D warnings
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          components: clippy
+          bins: cargo-cranky@0.3.0
+          channel: nightly
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo +nightly cranky --all-targets -- -D warnings
+
+  deny:
+    name: cargo deny --all-features check licenses
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+          bins: cargo-deny
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo deny --all-features check licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,18 @@
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = [
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 1.0

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,15 +1,15 @@
-extern crate shpool_pty;
-extern crate libc;
 extern crate errno;
+extern crate libc;
+extern crate shpool_pty;
 
 use shpool_pty::fork::*;
 use std::io::Read;
-use std::process::{Command};
+use std::process::Command;
 
 fn main() {
     let fork = Fork::from_ptmx().unwrap();
 
-    if let Some(mut master) = fork.is_parent().ok() {
+    if let Ok(mut master) = fork.is_parent() {
         // Read output via PTY master
         let mut output = String::new();
 

--- a/examples/new.rs
+++ b/examples/new.rs
@@ -1,5 +1,5 @@
-extern crate shpool_pty;
 extern crate libc;
+extern crate shpool_pty;
 
 use self::shpool_pty::prelude::*;
 
@@ -9,10 +9,12 @@ use std::process::{Command, Stdio};
 fn main() {
     let fork = Fork::from_ptmx().unwrap();
 
-    if let Some(mut master) = fork.is_parent().ok() {
+    if let Ok(mut master) = fork.is_parent() {
         let mut string = String::new();
 
-        master.read_to_string(&mut string).unwrap_or_else(|e| panic!("{}", e));
+        master
+            .read_to_string(&mut string)
+            .unwrap_or_else(|e| panic!("{}", e));
 
         let output = Command::new("tty")
             .stdin(Stdio::inherit())
@@ -24,12 +26,17 @@ fn main() {
         let parent_tty = output_str.trim();
         let child_tty = string.trim();
 
-        println!("child_tty(\"{}\")[{}] != \"{}\" => {}", child_tty, child_tty.len(), "", child_tty != "");
-        assert!(child_tty != "");
+        println!(
+            "child_tty(\"{}\")[{}] != \"\" => {}",
+            child_tty,
+            child_tty.len(),
+            !child_tty.is_empty()
+        );
+        assert!(!child_tty.is_empty());
         assert!(child_tty != parent_tty);
 
-        let mut parent_tty_dir: Vec<&str> = parent_tty.split("/").collect();
-        let mut child_tty_dir: Vec<&str> = child_tty.split("/").collect();
+        let mut parent_tty_dir: Vec<&str> = parent_tty.split('/').collect();
+        let mut child_tty_dir: Vec<&str> = child_tty.split('/').collect();
 
         parent_tty_dir.pop();
         child_tty_dir.pop();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-tabs_spaces=4
-hard_tabs=false

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1,21 +1,27 @@
 mod err;
 
-use ::libc;
+use libc;
 
 pub use self::err::DescriptorError;
 use std::ffi::CStr;
 use std::os::unix::io::RawFd;
 
+/// # Safety
+///
+/// Implmentations MUST only return valid fds from
+/// these methods. Callers MUST NOT use the fds once the
+/// returning object has fallen out of scope.
 pub unsafe trait Descriptor {
     /// If the descriptor has a valid fd, return it
     fn take_raw_fd(&mut self) -> Option<RawFd>;
 
     /// The constructor function `open` opens the path
     /// and returns the fd.
-    fn open(path: &CStr,
-            flag: libc::c_int,
-            mode: Option<libc::c_int>)
-            -> Result<RawFd, DescriptorError> {
+    fn open(
+        path: &CStr,
+        flag: libc::c_int,
+        mode: Option<libc::c_int>,
+    ) -> Result<RawFd, DescriptorError> {
         // Safety: we've just ensured that path is non-null and the
         // other params are valid by construction.
         unsafe {

--- a/src/fork/err.rs
+++ b/src/fork/err.rs
@@ -1,4 +1,4 @@
-use ::descriptor::DescriptorError;
+use descriptor::DescriptorError;
 use std::error::Error;
 use std::fmt;
 

--- a/src/fork/pty/master/err.rs
+++ b/src/fork/pty/master/err.rs
@@ -1,4 +1,4 @@
-use ::descriptor::DescriptorError;
+use descriptor::DescriptorError;
 use std::error::Error;
 use std::fmt;
 
@@ -34,7 +34,6 @@ impl Error for MasterError {
             MasterError::UnlockptError => "the `grantpt` has a error, errnois set appropriately.",
             MasterError::PtsnameError => "the `ptsname` has a error",
             MasterError::NoFdError => "already closed, no fd",
-
         }
     }
 

--- a/src/fork/pty/slave/err.rs
+++ b/src/fork/pty/slave/err.rs
@@ -1,4 +1,4 @@
-use ::descriptor::DescriptorError;
+use descriptor::DescriptorError;
 use std::error::Error;
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,28 +71,12 @@
 //! }
 //! ```
 
-#![crate_type = "lib"]
-
-#![cfg_attr(feature = "nightly", feature(plugin))]
-#![cfg_attr(feature = "lints", plugin(clippy))]
-#![cfg_attr(feature = "lints", deny(warnings))]
-#![deny(
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unstable_features,
-    unused_import_braces,
-    unused_features,
-    unused_qualifications,
-)]
-
-extern crate libc;
 extern crate errno;
+extern crate libc;
 extern crate log;
 
 mod descriptor;
 pub mod fork;
 pub mod prelude;
 
-const DEFAULT_PTMX: &'static str = "/dev/ptmx";
+const DEFAULT_PTMX: &str = "/dev/ptmx";

--- a/tests/it_can_read_write.rs
+++ b/tests/it_can_read_write.rs
@@ -1,17 +1,17 @@
-extern crate shpool_pty;
 extern crate libc;
+extern crate shpool_pty;
 
 use self::shpool_pty::prelude::*;
 
 use std::io::prelude::*;
-use std::string::String;
 use std::process::Command;
+use std::string::String;
 
-fn read_line(master:&mut Master) -> String {
+fn read_line(master: &mut Master) -> String {
     let mut buf = [0];
     let mut res = String::new();
     while buf[0] as char != '\n' {
-        master.read(&mut buf).expect("cannot read 1 byte");
+        master.read_exact(&mut buf).expect("cannot read 1 byte");
         res.push(buf[0] as char)
     }
     res
@@ -21,7 +21,7 @@ fn read_line(master:&mut Master) -> String {
 fn it_can_read_write() {
     let fork = Fork::from_ptmx().unwrap();
 
-    if let Some(mut master) = fork.is_parent().ok() {
+    if let Ok(mut master) = fork.is_parent() {
         let _ = master.write("echo readme!\n".to_string().as_bytes());
 
         read_line(&mut master); // this is the "echo readme!" we just sent

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -1,6 +1,6 @@
-extern crate shpool_pty;
-extern crate libc;
 extern crate errno;
+extern crate libc;
+extern crate shpool_pty;
 
 use self::shpool_pty::prelude::*;
 
@@ -12,10 +12,12 @@ use std::string::String;
 fn it_fork_with_new_pty() {
     let fork = Fork::from_ptmx().unwrap();
 
-    if let Some(mut master) = fork.is_parent().ok() {
+    if let Ok(mut master) = fork.is_parent() {
         let mut string = String::new();
 
-        master.read_to_string(&mut string).unwrap_or_else(|e| panic!("{}", e));
+        master
+            .read_to_string(&mut string)
+            .unwrap_or_else(|e| panic!("{}", e));
 
         let output = Command::new("tty")
             .stdin(Stdio::inherit())
@@ -27,14 +29,14 @@ fn it_fork_with_new_pty() {
         let parent_tty = output_str.trim();
         let child_tty = string.trim();
 
-        assert!(child_tty != "");
+        assert!(!child_tty.is_empty());
         assert!(child_tty != parent_tty);
 
         // only compare if parent is tty
         // travis runs the tests without tty
         if parent_tty != "not a tty" {
-            let mut parent_tty_dir: Vec<&str> = parent_tty.split("/").collect();
-            let mut child_tty_dir: Vec<&str> = child_tty.split("/").collect();
+            let mut parent_tty_dir: Vec<&str> = parent_tty.split('/').collect();
+            let mut child_tty_dir: Vec<&str> = child_tty.split('/').collect();
 
             parent_tty_dir.pop();
             child_tty_dir.pop();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,2 +1,2 @@
-mod it_fork_with_new_pty;
 mod it_can_read_write;
+mod it_fork_with_new_pty;


### PR DESCRIPTION
This should allow users to get a safer type to
use for shipping around an fd. This is required
in order to use the most modern nix version for
some of the APIs that shpool uses.

Also adding CI in this patch since it is missing.