### PR TITLE
add ptsname_r shim for macos

### DIFF
--- a/src/descriptor/err.rs
+++ b/src/descriptor/err.rs
@@ -28,7 +28,6 @@ impl Error for DescriptorError {
     }
 
     /// The function `cause` returns the lower-level cause of this error, if any.
-
     fn cause(&self) -> Option<&dyn Error> {
         None
     }

--- a/src/fork/pty/master/err.rs
+++ b/src/fork/pty/master/err.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::fmt;
 
 /// The alias `Result` learns `MasterError` possibility.
-
 pub type Result<T> = ::std::result::Result<T, MasterError>;
 
 /// The enum `MasterError` defines the possible errors from constructor Master.
@@ -18,7 +17,6 @@ pub enum MasterError {
 
 impl fmt::Display for MasterError {
     /// The function `fmt` formats the value using the given formatter.
-
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ::errno::errno())
     }
@@ -26,7 +24,6 @@ impl fmt::Display for MasterError {
 
 impl Error for MasterError {
     /// The function `description` returns a short description of the error.
-
     fn description(&self) -> &str {
         match *self {
             MasterError::BadDescriptor(_) => "the descriptor as occured an error",

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -1,6 +1,6 @@
 mod err;
 
-#[cfg(any(target_os = "macos"))]
+#[cfg(target_os = "macos")]
 mod ptsname_r_macos;
 
 use descriptor::Descriptor;
@@ -77,7 +77,7 @@ impl Master {
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 let result = libc::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
-                #[cfg(any(target_os = "macos"))]
+                #[cfg(target_os = "macos")]
                 let result = ptsname_r_macos::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
                 match result {
@@ -107,7 +107,7 @@ impl io::Read for Master {
                 }
             }
         } else {
-            Err(io::Error::new(io::ErrorKind::Other, "already closed"))
+            Err(io::Error::other("already closed"))
         }
     }
 }
@@ -122,7 +122,7 @@ impl io::Write for Master {
                 }
             }
         } else {
-            Err(io::Error::new(io::ErrorKind::Other, "already closed"))
+            Err(io::Error::other("already closed"))
         }
     }
 

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -82,7 +82,7 @@ impl Master {
 
                 match result {
                     0 => Ok(()),
-                    _ => Err(MasterError::PtsnameError),
+                    _ => Err(MasterError::PtsnameError), // should probably capture errno
                 }
             }
         } else {

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -73,6 +73,8 @@ impl Master {
                 let data: *mut u8 = &mut buf[0];
 
                 #[cfg(any(target_os = "linux", target_os = "android"))]
+                // Safety: the vector's memory is valid for the duration
+                // of the call
                 let result = libc::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
                 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -1,6 +1,6 @@
 mod err;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos"))]
 mod ptsname_r_macos;
 
 use descriptor::Descriptor;
@@ -77,7 +77,7 @@ impl Master {
                 // of the call
                 let result = libc::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
-                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                #[cfg(any(target_os = "macos"))]
                 let result = ptsname_r_macos::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
                 match result {

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -1,5 +1,8 @@
 mod err;
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod ptsname_r_macos;
+
 use descriptor::Descriptor;
 
 pub use self::err::{MasterError, Result};
@@ -66,13 +69,18 @@ impl Master {
     /// subsequent calls.
     pub fn ptsname_r(&self, buf: &mut [u8]) -> Result<()> {
         if let Some(fd) = self.pty {
-            // Safety: the vector's memory is valid for the duration
-            // of the call
             unsafe {
                 let data: *mut u8 = &mut buf[0];
-                match libc::ptsname_r(fd, data as *mut libc::c_char, buf.len()) {
+
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                let result = libc::ptsname_r(fd, data as *mut libc::c_char, buf.len());
+
+                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                let result = ptsname_r_macos::ptsname_r(fd, data as *mut libc::c_char, buf.len());
+
+                match result {
                     0 => Ok(()),
-                    _ => Err(MasterError::PtsnameError), // should probably capture errno
+                    _ => Err(MasterError::PtsnameError),
                 }
             }
         } else {

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -69,12 +69,12 @@ impl Master {
     /// subsequent calls.
     pub fn ptsname_r(&self, buf: &mut [u8]) -> Result<()> {
         if let Some(fd) = self.pty {
+            // Safety: the vector's memory is valid for the duration
+            // of the call
             unsafe {
                 let data: *mut u8 = &mut buf[0];
 
                 #[cfg(any(target_os = "linux", target_os = "android"))]
-                // Safety: the vector's memory is valid for the duration
-                // of the call
                 let result = libc::ptsname_r(fd, data as *mut libc::c_char, buf.len());
 
                 #[cfg(any(target_os = "macos"))]

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -23,21 +23,20 @@ pub unsafe fn ptsname_r(
         return *libc::__error();
     }
 
-    let mut len = 0;
-    while len < IOCTL_BUF_SIZE && ioctl_buf[len] != 0 {
-        len += 1;
-    }
-    len += 1;
+    let null_ptr = libc::memchr(ioctl_buf.as_ptr() as *const libc::c_void, 0, IOCTL_BUF_SIZE);
+
+    let len = if null_ptr.is_null() {
+        IOCTL_BUF_SIZE
+    } else {
+        let offset = (null_ptr as usize) - (ioctl_buf.as_ptr() as usize);
+        offset + 1 // include null terminator.
+    };
 
     if len > buflen {
         return libc::ERANGE;
     }
 
-    libc::memcpy(
-        buf as *mut libc::c_void,
-        ioctl_buf.as_ptr() as *const libc::c_void,
-        len,
-    );
+    std::ptr::copy(ioctl_buf.as_ptr(), buf, len);
 
     0
 }

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -6,6 +6,12 @@
 //! Based on: https://tarq.net/posts/ptsname-on-osx-with-rust/
 
 #[cfg(any(target_os = "macos"))]
+/// # Safety
+///
+/// Callers must uphold the following invariants:
+/// - `fd` must refer to an open master PTY file descriptor.
+/// - `buf` must point to a valid allocation with capacity of at least `buflen` bytes and the
+///    allocation must remain valid throughout the function call.
 pub unsafe fn ptsname_r(
     fd: libc::c_int,
     buf: *mut libc::c_char,
@@ -49,24 +55,29 @@ mod tests {
     #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_retrieves_valid_name() {
+        // Safety: calling libc function with valid flags.
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
         assert!(master_fd >= 0, "Failed to open master PTY");
 
+        // Safety: master_fd is a valid open file descriptor.
         unsafe {
             assert_eq!(libc::grantpt(master_fd), 0, "grantpt failed");
             assert_eq!(libc::unlockpt(master_fd), 0, "unlockpt failed");
         }
 
         let mut buf = vec![0u8; 1024];
+        // Safety: master_fd is valid, buf is a properly sized allocation.
         let result =
             unsafe { ptsname_r(master_fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 
+        // Safety: closing the fd opened above.
         unsafe {
             libc::close(master_fd);
         }
 
         assert_eq!(result, 0, "ptsname_r failed with error code: {}", result);
 
+        // Safety: buf contains a null-terminated string from ptsname_r.
         let name = unsafe { CStr::from_ptr(buf.as_ptr() as *const libc::c_char) };
         let name_str = name.to_str().expect("Invalid UTF-8 in PTY name");
 
@@ -80,18 +91,23 @@ mod tests {
     #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_buffer_too_small() {
+        // Safety: calling libc function with valid flags.
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
 
         if master_fd >= 0 {
+            // Safety: master_fd is a valid open file descriptor.
             unsafe {
                 libc::grantpt(master_fd);
                 libc::unlockpt(master_fd);
             }
 
             let mut buf = [0u8; 2];
+            // Safety: master_fd is valid, buf is a properly sized allocation though intentionally
+            // too small.
             let result =
                 unsafe { ptsname_r(master_fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 
+            // Safety: closing the fd opened above.
             unsafe {
                 libc::close(master_fd);
             }
@@ -104,6 +120,7 @@ mod tests {
     #[test]
     fn test_ptsname_r_invalid_fd() {
         let mut buf = vec![0u8; 1024];
+        // Safety: buf is a properly sized allocation.
         let result = unsafe { ptsname_r(-1, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 
         assert_ne!(result, 0, "Expected non-zero error code for invalid fd");
@@ -112,16 +129,20 @@ mod tests {
     #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_null_buffer() {
+        // Safety: calling libc function with valid flags.
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
 
         if master_fd >= 0 {
+            // Safety: master_fd is a valid open file descriptor.
             unsafe {
                 libc::grantpt(master_fd);
                 libc::unlockpt(master_fd);
             }
 
+            // Safety: function handles null buffer safely.
             let result = unsafe { ptsname_r(master_fd, std::ptr::null_mut(), 1024) };
 
+            // Safety: closing the fd opened above.
             unsafe {
                 libc::close(master_fd);
             }

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -1,0 +1,134 @@
+//! macOS/iOS implementation of ptsname_r
+//!
+//! As `ptsname_r()` is not available on macOS/iOS, this provides a compatible
+//! implementation using the `TIOCPTYGNAME` ioctl syscall.
+//!
+//! Based on: https://tarq.net/posts/ptsname-on-osx-with-rust/
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[inline]
+pub unsafe fn ptsname_r(
+    fd: libc::c_int,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+) -> libc::c_int {
+    const IOCTL_BUF_SIZE: usize = 128;
+
+    if buf.is_null() || buflen == 0 {
+        return libc::EINVAL;
+    }
+
+    let mut ioctl_buf: [libc::c_char; IOCTL_BUF_SIZE] = [0; IOCTL_BUF_SIZE];
+
+    if libc::ioctl(fd, libc::TIOCPTYGNAME as u64, &mut ioctl_buf) != 0 {
+        return *libc::__error();
+    }
+
+    let mut len = 0;
+    while len < IOCTL_BUF_SIZE && ioctl_buf[len] != 0 {
+        len += 1;
+    }
+    len += 1;
+
+    if len > buflen {
+        return libc::ERANGE;
+    }
+
+    libc::memcpy(
+        buf as *mut libc::c_void,
+        ioctl_buf.as_ptr() as *const libc::c_void,
+        len,
+    );
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_ptsname_r_retrieves_valid_name() {
+        let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
+        assert!(master_fd >= 0, "Failed to open master PTY");
+
+        unsafe {
+            assert_eq!(libc::grantpt(master_fd), 0, "grantpt failed");
+            assert_eq!(libc::unlockpt(master_fd), 0, "unlockpt failed");
+        }
+
+        let mut buf = vec![0u8; 1024];
+        let result =
+            unsafe { ptsname_r(master_fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+
+        unsafe {
+            libc::close(master_fd);
+        }
+
+        assert_eq!(result, 0, "ptsname_r failed with error code: {}", result);
+
+        let name = unsafe { CStr::from_ptr(buf.as_ptr() as *const libc::c_char) };
+        let name_str = name.to_str().expect("Invalid UTF-8 in PTY name");
+
+        assert!(
+            name_str.starts_with("/dev/ttys") || name_str.starts_with("/dev/pty"),
+            "Unexpected PTY name format: {}",
+            name_str
+        );
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_ptsname_r_buffer_too_small() {
+        let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
+
+        if master_fd >= 0 {
+            unsafe {
+                libc::grantpt(master_fd);
+                libc::unlockpt(master_fd);
+            }
+
+            let mut buf = [0u8; 2];
+            let result =
+                unsafe { ptsname_r(master_fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+
+            unsafe {
+                libc::close(master_fd);
+            }
+
+            assert_eq!(result, libc::ERANGE);
+        }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_ptsname_r_invalid_fd() {
+        let mut buf = vec![0u8; 1024];
+        let result = unsafe { ptsname_r(-1, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+
+        assert_ne!(result, 0, "Expected non-zero error code for invalid fd");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_ptsname_r_null_buffer() {
+        let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
+
+        if master_fd >= 0 {
+            unsafe {
+                libc::grantpt(master_fd);
+                libc::unlockpt(master_fd);
+            }
+
+            let result = unsafe { ptsname_r(master_fd, std::ptr::null_mut(), 1024) };
+
+            unsafe {
+                libc::close(master_fd);
+            }
+
+            assert_eq!(result, libc::EINVAL);
+        }
+    }
+}

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -20,7 +20,7 @@ pub unsafe fn ptsname_r(
 
     let mut ioctl_buf: [libc::c_char; IOCTL_BUF_SIZE] = [0; IOCTL_BUF_SIZE];
 
-    if libc::ioctl(fd, libc::TIOCPTYGNAME as u64, &mut ioctl_buf) != 0 {
+    if libc::ioctl(fd, libc::TIOCPTYGNAME as libc::c_ulong, &mut ioctl_buf) != 0 {
         return *libc::__error();
     }
 

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -1,12 +1,11 @@
-//! macOS/iOS implementation of ptsname_r
+//! macOS implementation of ptsname_r
 //!
-//! As `ptsname_r()` is not available on macOS/iOS, this provides a compatible
+//! As `ptsname_r()` is not available on macOS, this provides a compatible
 //! implementation using the `TIOCPTYGNAME` ioctl syscall.
 //!
 //! Based on: https://tarq.net/posts/ptsname-on-osx-with-rust/
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-#[inline]
+#[cfg(any(target_os = "macos"))]
 pub unsafe fn ptsname_r(
     fd: libc::c_int,
     buf: *mut libc::c_char,
@@ -48,7 +47,7 @@ mod tests {
     use super::*;
     use std::ffi::CStr;
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_retrieves_valid_name() {
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
@@ -79,7 +78,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_buffer_too_small() {
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
@@ -102,7 +101,7 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_invalid_fd() {
         let mut buf = vec![0u8; 1024];
@@ -111,7 +110,7 @@ mod tests {
         assert_ne!(result, 0, "Expected non-zero error code for invalid fd");
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos"))]
     #[test]
     fn test_ptsname_r_null_buffer() {
         let master_fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -5,13 +5,13 @@
 //!
 //! Based on: https://tarq.net/posts/ptsname-on-osx-with-rust/
 
-#[cfg(any(target_os = "macos"))]
+#[cfg(target_os = "macos")]
 /// # Safety
 ///
 /// Callers must uphold the following invariants:
 /// - `fd` must refer to an open master PTY file descriptor.
 /// - `buf` must point to a valid allocation with capacity of at least `buflen` bytes and the
-///    allocation must remain valid throughout the function call.
+///   allocation must remain valid throughout the function call.
 pub unsafe fn ptsname_r(
     fd: libc::c_int,
     buf: *mut libc::c_char,
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     use std::ffi::CStr;
 
-    #[cfg(any(target_os = "macos"))]
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_ptsname_r_retrieves_valid_name() {
         // Safety: calling libc function with valid flags.
@@ -88,7 +88,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "macos"))]
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_ptsname_r_buffer_too_small() {
         // Safety: calling libc function with valid flags.
@@ -116,7 +116,7 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_os = "macos"))]
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_ptsname_r_invalid_fd() {
         let mut buf = vec![0u8; 1024];
@@ -126,7 +126,7 @@ mod tests {
         assert_ne!(result, 0, "Expected non-zero error code for invalid fd");
     }
 
-    #[cfg(any(target_os = "macos"))]
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_ptsname_r_null_buffer() {
         // Safety: calling libc function with valid flags.

--- a/src/fork/pty/slave/err.rs
+++ b/src/fork/pty/slave/err.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::fmt;
 
 /// The alias `Result` learns `SlaveError` possibility.
-
 pub type Result<T> = ::std::result::Result<T, SlaveError>;
 
 /// The enum `SlaveError` defines the possible errors from constructor Slave.

--- a/tests/it_can_read_write.rs
+++ b/tests/it_can_read_write.rs
@@ -28,6 +28,16 @@ fn it_can_read_write() {
         assert_eq!(read_line(&mut master).trim(), "readme!");
         let _ = master.write("exit\n".to_string().as_bytes());
     } else {
-        let _ = Command::new("sh").env_clear().status();
+        let mut cmd = Command::new("bash");
+        cmd.env_clear();
+
+        // On macOS, silence the deprecation warning;
+        // https://github.com/apple-oss-distributions/bash/blob/e86b2aa8e37a31f8fce56366d1abaf08a3fac7d2/bash-3.2/shell.c#L760-L765
+        #[cfg(target_os = "macos")]
+        {
+            cmd.env("BASH_SILENCE_DEPRECATION_WARNING", "1");
+        }
+
+        let _ = cmd.status();
     }
 }

--- a/tests/it_can_read_write.rs
+++ b/tests/it_can_read_write.rs
@@ -28,6 +28,6 @@ fn it_can_read_write() {
         assert_eq!(read_line(&mut master).trim(), "readme!");
         let _ = master.write("exit\n".to_string().as_bytes());
     } else {
-        let _ = Command::new("bash").env_clear().status();
+        let _ = Command::new("sh").env_clear().status();
     }
 }


### PR DESCRIPTION
Related to; https://github.com/shell-pool/shpool/issues/183

I was not able to build [shell-pool/shpool](https://github.com/shell-pool/shpool);
```
error[E0425]: cannot find function `ptsname_r` in crate `libc`
    --> src/fork/pty/master/mod.rs:73:29
     |
73   |                 match libc::ptsname_r(fd, data as *mut libc::c_char, buf.len()) {
     |                             ^^^^^^^^^ help: a function with a similar name exists: `ptsname`
```

With a quick search I found these references:
- https://github.com/Mobivity/nix-ptsname_r-shim
- https://tarq.net/posts/ptsname-on-osx-with-rust/


This PR adds a small macOS-only shim so that from the caller’s perspective, it still looks like `ibc::ptsname_r`, to make as little as change possible.

I have little to no experience in Rust or systems programming, so this change
may not be idiomatic or does not even make sense in the first place so feel
free to update/feedback or even discard.

I've been using it on on my [shpool fork](https://github.com/seruman/shpool/tree/macos) for couple some time just fine.

Disclaimer; got help from LLM tools, especially for tests.



--- 

Had to change tests to use `sh` instead of `bash` for portability as on my version of macOS -26.0.1-, Apple provided `bash` greets you with;
```
The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.
```

And seems like [it is baked in.](https://github.com/apple-oss-distributions/bash/blob/e86b2aa8e37a31f8fce56366d1abaf08a3fac7d2/bash-3.2/shell.c#L760-L765)


