### PR TITLE
chore: switch to shpool rustfmt

### DIFF
--- a/examples/new.rs
+++ b/examples/new.rs
@@ -12,15 +12,9 @@ fn main() {
     if let Ok(mut master) = fork.is_parent() {
         let mut string = String::new();
 
-        master
-            .read_to_string(&mut string)
-            .unwrap_or_else(|e| panic!("{}", e));
+        master.read_to_string(&mut string).unwrap_or_else(|e| panic!("{}", e));
 
-        let output = Command::new("tty")
-            .stdin(Stdio::inherit())
-            .output()
-            .unwrap()
-            .stdout;
+        let output = Command::new("tty").stdin(Stdio::inherit()).output().unwrap().stdout;
         let output_str = String::from_utf8_lossy(&output);
 
         let parent_tty = output_str.trim();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+# Use: `cargo +nightly fmt`
+
+edition = "2021"
+style_edition = "2021"
+use_small_heuristics = "Max"
+newline_style = "Unix"
+wrap_comments = true
+format_generated_files = false

--- a/src/descriptor/err.rs
+++ b/src/descriptor/err.rs
@@ -27,7 +27,8 @@ impl Error for DescriptorError {
         }
     }
 
-    /// The function `cause` returns the lower-level cause of this error, if any.
+    /// The function `cause` returns the lower-level cause of this error, if
+    /// any.
     fn cause(&self) -> Option<&dyn Error> {
         None
     }

--- a/src/fork/err.rs
+++ b/src/fork/err.rs
@@ -58,7 +58,8 @@ impl Error for ForkError {
         }
     }
 
-    /// The function `cause` returns the lower-level cause of this error, if any.
+    /// The function `cause` returns the lower-level cause of this error, if
+    /// any.
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ForkError::BadMaster(ref err) => Some(err),

--- a/src/fork/pty/master/err.rs
+++ b/src/fork/pty/master/err.rs
@@ -32,7 +32,8 @@ impl Error for MasterError {
         }
     }
 
-    /// The function `cause` returns the lower-level cause of this error, if any.
+    /// The function `cause` returns the lower-level cause of this error, if
+    /// any.
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             MasterError::BadDescriptor(ref err) => Some(err),

--- a/src/fork/pty/master/mod.rs
+++ b/src/fork/pty/master/mod.rs
@@ -91,11 +91,7 @@ impl io::Read for Master {
         // Safety: the vector's memory is valid for the duration
         // of the call
         unsafe {
-            match libc::read(
-                self.raw_fd(),
-                buf.as_mut_ptr() as *mut libc::c_void,
-                buf.len(),
-            ) {
+            match libc::read(self.raw_fd(), buf.as_mut_ptr() as *mut libc::c_void, buf.len()) {
                 -1 => Ok(0),
                 len => Ok(len as usize),
             }
@@ -106,11 +102,7 @@ impl io::Read for Master {
 impl io::Write for Master {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         unsafe {
-            match libc::write(
-                self.raw_fd(),
-                buf.as_ptr() as *const libc::c_void,
-                buf.len(),
-            ) {
+            match libc::write(self.raw_fd(), buf.as_ptr() as *const libc::c_void, buf.len()) {
                 -1 => Err(io::Error::last_os_error()),
                 ret => Ok(ret as usize),
             }

--- a/src/fork/pty/master/ptsname_r_macos.rs
+++ b/src/fork/pty/master/ptsname_r_macos.rs
@@ -10,8 +10,8 @@
 ///
 /// Callers must uphold the following invariants:
 /// - `fd` must refer to an open master PTY file descriptor.
-/// - `buf` must point to a valid allocation with capacity of at least `buflen` bytes and the
-///   allocation must remain valid throughout the function call.
+/// - `buf` must point to a valid allocation with capacity of at least `buflen`
+///   bytes and the allocation must remain valid throughout the function call.
 pub unsafe fn ptsname_r(
     fd: libc::c_int,
     buf: *mut libc::c_char,
@@ -102,8 +102,8 @@ mod tests {
             }
 
             let mut buf = [0u8; 2];
-            // Safety: master_fd is valid, buf is a properly sized allocation though intentionally
-            // too small.
+            // Safety: master_fd is valid, buf is a properly sized allocation though
+            // intentionally too small.
             let result =
                 unsafe { ptsname_r(master_fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 

--- a/src/fork/pty/slave/err.rs
+++ b/src/fork/pty/slave/err.rs
@@ -28,7 +28,8 @@ impl Error for SlaveError {
         }
     }
 
-    /// The function `cause` returns the lower-level cause of this error, if any.
+    /// The function `cause` returns the lower-level cause of this error, if
+    /// any.
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             SlaveError::BadDescriptor(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! # PTY
 //!
-//! [![Crate][crate-badge]][crate] [![docs-badge][]][docs] [![license-badge][]][license] [![travis-badge][]][travis]
+//! [![Crate][crate-badge]][crate] [![docs-badge][]][docs]
+//! [![license-badge][]][license] [![travis-badge][]][travis]
 //!
 //! [crate-badge]: https://img.shields.io/badge/crates.io-v0.2.0-orange.svg?style=flat-square
 //! [crate]: https://crates.io/crates/pty
@@ -14,7 +15,8 @@
 //! [travis-badge]: https://travis-ci.org/hibariya/pty-rs.svg?branch=master&style=flat-square
 //! [travis]: https://travis-ci.org/hibariya/pty-rs
 //!
-//! The `pty` crate provides `pty::fork()`. That makes a parent process fork with new pseudo-terminal (PTY).
+//! The `pty` crate provides `pty::fork()`. That makes a parent process fork
+//! with new pseudo-terminal (PTY).
 //!
 //! This crate depends on followings:
 //!
@@ -38,9 +40,11 @@
 //!
 //! ### pty::fork()
 //!
-//! This function returns `pty::Child`. It represents the child process and its PTY.
+//! This function returns `pty::Child`. It represents the child process and its
+//! PTY.
 //!
-//! For example, the following code spawns `tty(1)` command by `pty::fork()` and outputs the result of the command.
+//! For example, the following code spawns `tty(1)` command by `pty::fork()` and
+//! outputs the result of the command.
 //!
 //! ```rust
 //! extern crate shpool_pty;

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -14,15 +14,9 @@ fn it_fork_with_new_pty() {
     if let Ok(mut master) = fork.is_parent() {
         let mut string = String::new();
 
-        master
-            .read_to_string(&mut string)
-            .unwrap_or_else(|e| panic!("{}", e));
+        master.read_to_string(&mut string).unwrap_or_else(|e| panic!("{}", e));
 
-        let output = Command::new("tty")
-            .stdin(Stdio::inherit())
-            .output()
-            .unwrap()
-            .stdout;
+        let output = Command::new("tty").stdin(Stdio::inherit()).output().unwrap().stdout;
         let output_str = String::from_utf8_lossy(&output);
 
         let parent_tty = output_str.trim();

--- a/tests/it_protects_against_use_after_free.rs
+++ b/tests/it_protects_against_use_after_free.rs
@@ -18,10 +18,7 @@ fn it_drops_correctly() {
     let fd = master.raw_fd();
 
     // Check if fd is valid
-    assert!(
-        unsafe { libc::fcntl(fd, libc::F_GETFD) } != -1,
-        "FD should be valid"
-    );
+    assert!(unsafe { libc::fcntl(fd, libc::F_GETFD) } != -1, "FD should be valid");
 
     let master_clone = master.clone();
     assert_eq!(master.raw_fd(), master_clone.raw_fd());
@@ -42,10 +39,7 @@ fn it_drops_correctly() {
 
     drop(fork);
     // Now it should be closed
-    assert!(
-        unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1,
-        "FD should be closed after last drop"
-    );
+    assert!(unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1, "FD should be closed after last drop");
 }
 
 #[test]


### PR DESCRIPTION
This switches the rustfmt config to match the one we use for the main shpool repo.